### PR TITLE
mxm_wifiex: fix the build errors with the API changes on L5.19.2 kernel

### DIFF
--- a/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.c
@@ -1140,7 +1140,11 @@ int woal_cfg80211_change_virtual_intf(struct wiphy *wiphy,
 #endif /* WIFI_DIRECT_SUPPORT */
 #if defined(STA_SUPPORT) && defined(UAP_SUPPORT)
 		if (priv->bss_type == MLAN_BSS_TYPE_UAP) {
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+			woal_cfg80211_del_beacon(wiphy, dev, 0);
+#else
 			woal_cfg80211_del_beacon(wiphy, dev);
+#endif
 			bss_role = MLAN_BSS_ROLE_STA;
 			woal_cfg80211_bss_role_cfg(priv, MLAN_ACT_SET,
 						   &bss_role);
@@ -2107,6 +2111,9 @@ done:
  * @return                0 -- success, otherwise fail
  */
 int woal_cfg80211_set_bitrate_mask(struct wiphy *wiphy, struct net_device *dev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+				   unsigned int link_id,
+#endif
 				   const u8 *peer,
 				   const struct cfg80211_bitrate_mask *mask)
 {
@@ -4781,7 +4788,11 @@ void woal_cfg80211_notify_channel(moal_private *priv,
 #if KERNEL_VERSION(3, 8, 0) <= CFG80211_VERSION_CODE
 	if (MLAN_STATUS_SUCCESS ==
 	    woal_chandef_create(priv, &chandef, pchan_info)) {
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+		cfg80211_ch_switch_notify(priv->netdev, &chandef, 0);
+#else
 		cfg80211_ch_switch_notify(priv->netdev, &chandef);
+#endif
 		priv->channel = pchan_info->channel;
 #ifdef UAP_CFG80211
 		moal_memcpy_ext(priv->phandle, &priv->chan, &chandef,

--- a/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.h
+++ b/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.h
@@ -156,6 +156,9 @@ int woal_cfg80211_flush_pmksa(struct wiphy *wiphy, struct net_device *dev);
 #endif
 
 int woal_cfg80211_set_bitrate_mask(struct wiphy *wiphy, struct net_device *dev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+				   unsigned int link_id,
+#endif
 				   const u8 *peer,
 				   const struct cfg80211_bitrate_mask *mask);
 #if KERNEL_VERSION(2, 6, 38) <= CFG80211_VERSION_CODE
@@ -418,7 +421,12 @@ int woal_cfg80211_set_beacon(struct wiphy *wiphy, struct net_device *dev,
 			     struct beacon_parameters *params);
 #endif
 
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+int woal_cfg80211_del_beacon(struct wiphy *wiphy, struct net_device *dev, unsigned int link_id);
+#else
 int woal_cfg80211_del_beacon(struct wiphy *wiphy, struct net_device *dev);
+#endif
+
 int woal_cfg80211_del_station(struct wiphy *wiphy, struct net_device *dev,
 #if KERNEL_VERSION(3, 19, 0) <= CFG80211_VERSION_CODE
 			      struct station_del_parameters *param);

--- a/mxm_wifiex/wlan_src/mlinux/moal_main.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_main.c
@@ -21,6 +21,7 @@
  *
  */
 
+
 /********************************************************
 Change log:
     10/21/2008: initial version
@@ -963,7 +964,11 @@ static void woal_hang_work_queue(struct work_struct *work)
 #ifdef STA_CFG80211
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)
 			if (IS_STA_CFG80211(cfg80211_wext) && priv->wdev &&
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+			    priv->wdev->u.ibss.current_bss) {
+#else
 			    priv->wdev->current_bss) {
+#endif
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
 				if (priv->host_mlme)
 					woal_host_mlme_disconnect(
@@ -5682,7 +5687,11 @@ int woal_close(struct net_device *dev)
 	woal_cancel_scan(priv, MOAL_IOCTL_WAIT);
 
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+	if (IS_STA_CFG80211(cfg80211_wext) && priv->wdev->u.ibss.current_bss) {
+#else
 	if (IS_STA_CFG80211(cfg80211_wext) && priv->wdev->current_bss) {
+#endif
 		priv->cfg_disconnect = MTRUE;
 		cfg80211_disconnected(priv->netdev, 0, NULL, 0,
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
@@ -8637,7 +8646,11 @@ t_void woal_send_disconnect_to_system(moal_private *priv,
 	if (IS_STA_CFG80211(cfg80211_wext)) {
 		spin_lock_irqsave(&priv->connect_lock, flags);
 		if (!priv->cfg_disconnect && !priv->cfg_connect && priv->wdev &&
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+		    priv->wdev->u.ibss.current_bss) {
+#else
 		    priv->wdev->current_bss) {
+#endif
 			PRINTM(MMSG,
 			       "wlan: Disconnected from " MACSTR
 			       ": Reason code %d\n",

--- a/mxm_wifiex/wlan_src/mlinux/moal_sdio_mmc.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_sdio_mmc.c
@@ -2512,3 +2512,5 @@ static moal_if_ops sdiommc_ops = {
 	.reg_dbg = woal_sdiommc_reg_dbg,
 	.is_second_mac = woal_sdiommc_is_second_mac,
 };
+
+MODULE_DEVICE_TABLE(sdio, wlan_ids);

--- a/mxm_wifiex/wlan_src/mlinux/moal_shim.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_shim.c
@@ -3367,7 +3367,12 @@ mlan_status moal_recv_event(t_void *pmoal, pmlan_event pmevent)
 			PRINTM(MMSG,
 			       "Channel Under Nop: notify cfg80211 new channel=%d\n",
 			       priv->channel);
+
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+			cfg80211_ch_switch_notify(priv->netdev, &priv->chan, 0);
+#else
 			cfg80211_ch_switch_notify(priv->netdev, &priv->chan);
+#endif
 			priv->chan_under_nop = MFALSE;
 		}
 #endif
@@ -3688,7 +3693,11 @@ mlan_status moal_recv_event(t_void *pmoal, pmlan_event pmevent)
 						PRINTM(MEVENT,
 						       "HostMlme %s: Receive deauth/disassociate\n",
 						       priv->netdev->name);
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+						if (!priv->wdev->u.ibss.current_bss) {
+#else
 						if (!priv->wdev->current_bss) {
+#endif
 							PRINTM(MEVENT,
 							       "HostMlme: Drop deauth/disassociate, current_bss = null\n");
 							break;

--- a/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
@@ -103,6 +103,9 @@ static int woal_cfg80211_dump_survey(struct wiphy *wiphy,
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
 static int woal_cfg80211_get_channel(struct wiphy *wiphy,
 				     struct wireless_dev *wdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+				     unsigned int link_id,
+#endif
 				     struct cfg80211_chan_def *chandef);
 #endif
 static int woal_cfg80211_set_power_mgmt(struct wiphy *wiphy,
@@ -5300,7 +5303,11 @@ static int woal_cfg80211_disconnect(struct wiphy *wiphy, struct net_device *dev,
 	if (priv->media_connected == MFALSE) {
 		PRINTM(MMSG, " Already disconnected\n");
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+		if (priv->wdev->u.ibss.current_bss &&
+#else
 		if (priv->wdev->current_bss &&
+#endif
 		    (priv->wdev->iftype == NL80211_IFTYPE_STATION ||
 		     priv->wdev->iftype == NL80211_IFTYPE_P2P_CLIENT)) {
 			priv->cfg_disconnect = MTRUE;
@@ -5628,6 +5635,9 @@ done:
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
 static int woal_cfg80211_get_channel(struct wiphy *wiphy,
 				     struct wireless_dev *wdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+				     unsigned int link_id,
+#endif
 				     struct cfg80211_chan_def *chandef)
 {
 	moal_private *priv = (moal_private *)woal_get_netdev_priv(wdev->netdev);


### PR DESCRIPTION
    L5.19.2 kernel added preliminary support to MLO link API to
    include/net/cfg80211.h.
    Added unused link_id parameters to
        woal_cfg80211_set_bitrate_mask(),
        woal_cfg80211_get_channel(),
        woal_cfg80211_del_beacon().

    Updated access of fields  moved from wireless_dev to wireless_dev.u.ibss
    in L5.19.2

    struct wireless_dev {
	union {
		struct {
			struct cfg80211_internal_bss *current_bss;
			struct cfg80211_chan_def chandef;
			int beacon_interval;
			u8 ssid[IEEE80211_MAX_SSID_LEN];
			u8 ssid_len;
		} ibss;
	} u;
    }

mxm_wifiex: made compatible with v5.19.2+ MLO link APIs see kernel commit 7a53ad13c09150076b7ddde96c2dfc5622c90b45