### PR TITLE
mxm_wifiex: allow to overwrite CONFIG_IMX_SUPPORT

### DIFF
--- a/mxm_wifiex/wlan_src/Makefile
+++ b/mxm_wifiex/wlan_src/Makefile
@@ -125,7 +125,7 @@ ccflags-y += -DLINUX
 
 
 ARCH ?= arm64
-CONFIG_IMX_SUPPORT=y
+CONFIG_IMX_SUPPORT ?= y
 ifeq ($(CONFIG_IMX_SUPPORT),y)
 ccflags-y += -DIMX_SUPPORT
 ifneq ($(ANDROID_PRODUCT_OUT),)


### PR DESCRIPTION
Config value is set to "n" when build on non-i.MX platforms, for example x86_64.