### PR TITLE
mxm_wifiex: add modules_install target

### DIFF
--- a/mxm_wifiex/wlan_src/Makefile
+++ b/mxm_wifiex/wlan_src/Makefile
@@ -660,6 +660,9 @@ install: default
 	echo $(INSTALLDIR)
 	echo "MX Driver Installed"
 
+modules_install:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) INSTALL_MOD_DIR=$(INSTALLDIR) modules_install
+
 distclean:
 	-find . -name "*.o" -exec rm {} \;
 	-find . -name "*.orig" -exec rm {} \;


### PR DESCRIPTION
To install out-of-tree kernel module, as per documentation:

    modules_install
        Install the external module(s). The default location is
        /lib/modules/<kernel_release>/extra/, but a prefix may
        be added with INSTALL_MOD_PATH (discussed in section 5).

Link: https://www.kernel.org/doc/Documentation/kbuild/modules.txt