### PR TITLE
mxm_wifiex: Decrement refcount after ref dt node.

### DIFF
--- a/mxm_wifiex/wlan_src/mlinux/moal_init.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_init.c
@@ -2454,6 +2454,7 @@ void woal_init_from_dev_tree(void)
 #endif
 #endif
 	}
+	of_node_put(dt_node);
 	LEAVE();
 	return;
 }


### PR DESCRIPTION
The node pointer with refcount incremented by of_find_node_by_name(), use of_node_put() on it when done.