### PR TITLE
mxm_wifiex: Null-terminate buffer for user data

### DIFF
--- a/mlinux/moal_proc.c
+++ b/mlinux/moal_proc.c
@@ -634,7 +634,8 @@ static ssize_t woal_config_write(struct file *f, const char __user *buf,
 	}
 
 	flag = (in_atomic() || irqs_disabled()) ? GFP_ATOMIC : GFP_KERNEL;
-	databuf = kzalloc(count, flag);
+	/* Allocate additional byte for null-termination in case user buffer wasn't null-terminated */
+	databuf = kzalloc(count + 1, flag);
 	if (databuf == NULL) {
 		LEAVE();
 		return -ENOMEM;


### PR DESCRIPTION
During stress-ng testing on Ubuntu 24.04:

stress-ng --procfs 0 --timeout 30 --oom-avoid-bytes 10% --skip-silent --verbose

There is a series of segfaults caused by data buffer having exactly the same amount of bytes that the user data. In case user passes a string that is not null-terminated, this can cause OOB reads during strncmp.