### PR TITLE
Build for linux kernel 4.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,8 @@ ccflags-y += -DLINUX
 
 
 
-ARCH ?= arm64
-CONFIG_IMX_SUPPORT=y
+ARCH ?= arm
+CONFIG_IMX_SUPPORT=n
 ifeq ($(CONFIG_IMX_SUPPORT),y)
 ccflags-y += -DIMX_SUPPORT
 ifneq ($(ANDROID_PRODUCT_OUT),)

--- a/mlinux/moal_main.h
+++ b/mlinux/moal_main.h
@@ -28,6 +28,16 @@ Change log:
 #ifndef _MOAL_MAIN_H
 #define _MOAL_MAIN_H
 
+#ifndef fallthrough
+#if defined(__GNUC__) && __GNUC__ >= 7
+#define fallthrough __attribute__((fallthrough))
+#elif defined(__clang__) && __clang_major__ >= 10
+#define fallthrough __attribute__((fallthrough))
+#else
+#define fallthrough ((void)0)
+#endif
+#endif
+
 /* warnfix for FS redefination if any? */
 #ifdef FS
 #undef FS

--- a/mlinux/moal_sta_cfg80211.c
+++ b/mlinux/moal_sta_cfg80211.c
@@ -4653,7 +4653,7 @@ static mlan_status woal_cfg80211_dump_station_info(moal_private *priv,
 #endif
 #endif
 
-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
 	sinfo->filled |= MBIT64(NL80211_STA_INFO_FCS_ERROR_COUNT);
 #endif
 
@@ -4687,7 +4687,7 @@ static mlan_status woal_cfg80211_dump_station_info(moal_private *priv,
 	sinfo->tx_failed = stats.failed;
 	sinfo->tx_retries = stats.retry;
 #endif
-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
 	sinfo->fcs_err_count = stats.fcs_error;
 #endif
 


### PR DESCRIPTION
Some minor changes to build linux driver for kernel version 4.19. 

The driver was cross-compiled for arm platform (TI Sitara AM437x), NXP specific code was switched off (CONFIG_IMX_SUPPORT=n).

Note, that enum item for 6GHz band NL80211_BAND_6GHZ introduced in later kernel version.
Driver code was not changed in the driver, just dummy NL80211_BAND_6GHZ was added in include/uapi/linux/nl80211.h
