### PR TITLE
Build fixes for 7.2 Kernels

### DIFF
--- a/mlinux/moal_cfg80211_util.c
+++ b/mlinux/moal_cfg80211_util.c
@@ -1002,7 +1002,7 @@ static int woal_cfg80211_subcmd_set_country_code(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 		case ATTR_COUNTRY_CODE:
-			strncpy(country, nla_data(iter),
+			strscpy(country, nla_data(iter),
 				MIN((int)sizeof(country) - 1, nla_len(iter)));
 			break;
 		default:
@@ -1302,7 +1302,7 @@ static int woal_cfg80211_subcmd_start_logging(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 		case ATTR_WIFI_LOGGER_RING_ID:
-			strncpy(ring_name, nla_data(iter),
+			strscpy(ring_name, nla_data(iter),
 				MIN(sizeof(ring_name) - 1, nla_len(iter)));
 			break;
 		case ATTR_WIFI_LOGGER_VERBOSE_LEVEL:
@@ -1397,7 +1397,7 @@ static int woal_cfg80211_subcmd_get_ring_data(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 		case ATTR_WIFI_LOGGER_RING_ID:
-			strncpy(ring_name, nla_data(iter),
+			strscpy(ring_name, nla_data(iter),
 				MIN(sizeof(ring_name) - 1, nla_len(iter)));
 			break;
 		default:

--- a/mlinux/moal_eth_ioctl.c
+++ b/mlinux/moal_eth_ioctl.c
@@ -7797,7 +7797,7 @@ static int woal_priv_regrdwr(moal_private *priv, t_u8 *respbuf,
 		ret = -ENOMEM;
 		goto done;
 	}
-	strncpy(arguments, respbuf + header_len,
+	strscpy(arguments, respbuf + header_len,
 		strlen(respbuf) * sizeof(char));
 	/* respbuf is already null-terminated by calling function and hence
 	 * arguments is also null-terminated

--- a/mlinux/moal_init.c
+++ b/mlinux/moal_init.c
@@ -1307,7 +1307,7 @@ static mlan_status parse_cfg_read_block(t_u8 *data, t_u32 size,
 			if (params->txpwrlimit_cfg) {
 				memset(handle->mode_psd_file, 0,
 				       sizeof(handle->mode_psd_file));
-				strncpy(handle->mode_psd_file,
+				strscpy(handle->mode_psd_file,
 					params->txpwrlimit_cfg,
 					sizeof(handle->mode_psd_file) - 1);
 				handle->mode_psd_file
@@ -2243,7 +2243,7 @@ static void woal_setup_module_param(moal_handle *handle, moal_mod_para *params)
 
 	if (handle->params.txpwrlimit_cfg) {
 		memset(handle->mode_psd_file, 0, sizeof(handle->mode_psd_file));
-		strncpy(handle->mode_psd_file, handle->params.txpwrlimit_cfg,
+		strscpy(handle->mode_psd_file, handle->params.txpwrlimit_cfg,
 			sizeof(handle->mode_psd_file) - 1);
 		handle->mode_psd_file[sizeof(handle->mode_psd_file) - 1] = '\0';
 		PRINTM(MINFO, "Mode PSD file name: %s", handle->mode_psd_file);

--- a/mlinux/moal_ioctl.c
+++ b/mlinux/moal_ioctl.c
@@ -2342,17 +2342,17 @@ mlan_status woal_request_get_fw_info(moal_private *priv, t_u8 wait_option,
 				&info->param.fw_info.fw_ver,
 				sizeof(info->param.fw_info.fw_ver),
 				sizeof(priv->phandle->fw_release_number));
-		strncpy(priv->phandle->fw_ver_milestone,
+		strscpy(priv->phandle->fw_ver_milestone,
 			info->param.fw_info.fw_ver_milestone,
 			sizeof(priv->phandle->fw_ver_milestone) - 1);
 		priv->phandle->fw_ver_milestone
 			[sizeof(priv->phandle->fw_ver_milestone) - 1] = '\0';
-		strncpy(priv->phandle->fw_ver_buildtype,
+		strscpy(priv->phandle->fw_ver_buildtype,
 			info->param.fw_info.fw_ver_buildtype,
 			sizeof(priv->phandle->fw_ver_buildtype) - 1);
 		priv->phandle->fw_ver_buildtype
 			[sizeof(priv->phandle->fw_ver_buildtype) - 1] = '\0';
-		strncpy(priv->phandle->fw_ver_data,
+		strscpy(priv->phandle->fw_ver_data,
 			info->param.fw_info.fw_ver_data,
 			sizeof(priv->phandle->fw_ver_data) - 1);
 		priv->phandle
@@ -6442,7 +6442,7 @@ mlan_status woal_set_bg_scan(moal_private *priv, char *buf, int length)
 			}
 			if (ssid_len &&
 			    (num_ssid < (MRVDRV_MAX_SSID_LIST_LENGTH - 1))) {
-				strncpy(priv->scan_cfg.ssid_list[num_ssid].ssid,
+				strscpy(priv->scan_cfg.ssid_list[num_ssid].ssid,
 					ptr + 2, ssid_len);
 				priv->scan_cfg.ssid_list[num_ssid].max_len = 0;
 				PRINTM(MIOCTL, "BG scan: ssid=%s\n",
@@ -6554,7 +6554,7 @@ void woal_config_bgscan_and_rssi(moal_private *priv, t_u8 set_rssi)
 		return;
 	}
 	memset(&priv->scan_cfg, 0, sizeof(priv->scan_cfg));
-	strncpy(priv->scan_cfg.ssid_list[0].ssid, bss_info.ssid.ssid,
+	strscpy(priv->scan_cfg.ssid_list[0].ssid, bss_info.ssid.ssid,
 		bss_info.ssid.ssid_len);
 	priv->scan_cfg.ssid_list[0].max_len = 0;
 
@@ -7133,7 +7133,7 @@ int woal_set_combo_scan(moal_private *priv, char *buf, int length)
 			}
 			if (ssid_len &&
 			    (num_ssid < (MRVDRV_MAX_SSID_LIST_LENGTH - 1))) {
-				strncpy(scan_cfg->ssid_list[num_ssid].ssid,
+				strscpy(scan_cfg->ssid_list[num_ssid].ssid,
 					ptr + 2, ssid_len);
 				scan_cfg->ssid_list[num_ssid].max_len = 0;
 				PRINTM(MIOCTL, "Combo scan: ssid=%s\n",
@@ -9479,7 +9479,7 @@ static int parse_set_debug_temperature(const char *s, size_t len,
 		goto done;
 	}
 
-	strncpy(string, s + prefix_len, MAX_THERMAL_SIMULATION_LEN - 1);
+	strscpy(string, s + prefix_len, MAX_THERMAL_SIMULATION_LEN - 1);
 	string[MAX_THERMAL_SIMULATION_LEN - 1] = '\0';
 
 	temp = strstrip(string);

--- a/mlinux/moal_main.c
+++ b/mlinux/moal_main.c
@@ -3204,7 +3204,7 @@ static t_u32 woal_process_init_cfg(moal_handle *handle, const t_u8 *data,
 			else
 				intf_e = NULL;
 			if (intf_s != NULL && intf_e != NULL) {
-				strncpy(bss_mac_addr, intf_e + 1,
+				strscpy(bss_mac_addr, intf_e + 1,
 					MAX_MAC_ADDR_LEN - 1);
 				bss_mac_addr[MAX_MAC_ADDR_LEN - 1] = '\0';
 				if ((intf_e - intf_s) > MAX_PARAM_LEN) {
@@ -3220,7 +3220,7 @@ static t_u32 woal_process_init_cfg(moal_handle *handle, const t_u8 *data,
 					       __LINE__);
 					goto done;
 				}
-				strncpy(bss_mac_name, intf_s + 1, j);
+				strscpy(bss_mac_name, intf_s + 1, j);
 				bss_mac_name[j] = '\0';
 				for (i = 0; i < handle->priv_num; i++) {
 					if (!handle->priv[i])
@@ -3301,7 +3301,7 @@ static t_u32 woal_process_init_cfg(moal_handle *handle, const t_u8 *data,
 				intf_e = NULL;
 			if (intf_s != NULL && intf_e != NULL) {
 				/* Copy type */
-				strncpy(type, intf_s + 1, 1);
+				strscpy(type, intf_s + 1, 1);
 				type[1] = '\0';
 			} else {
 				PRINTM(MERROR, "Wrong config file format %d\n",
@@ -3325,7 +3325,7 @@ static t_u32 woal_process_init_cfg(moal_handle *handle, const t_u8 *data,
 					goto done;
 				}
 				/* Copy offset */
-				strncpy(offset, intf_s, j);
+				strscpy(offset, intf_s, j);
 				offset[j] = '\0';
 			} else {
 				PRINTM(MERROR, "Wrong config file format %d\n",
@@ -3409,7 +3409,7 @@ static mlan_status woal_process_hostcmd_cfg(moal_private *priv, t_u8 *data,
 		goto done;
 	}
 	ptr = buf;
-	strncpy(ptr, CMD_STR, CMD_BUF_LEN);
+	strscpy(ptr, CMD_STR, CMD_BUF_LEN);
 	ptr = buf + strlen(CMD_STR) + sizeof(t_u32);
 	while ((pos - data) < size) {
 		temp = pos;
@@ -6597,7 +6597,7 @@ moal_private *woal_add_interface(moal_handle *handle, t_u8 bss_index,
 		}
 	}
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 12, 0)
-	strncpy(csa_str, "CSA", sizeof(csa_str));
+	strscpy(csa_str, "CSA", sizeof(csa_str));
 	strncat(csa_str, name, sizeof(csa_str) - 4);
 	priv->csa_workqueue = alloc_workqueue(
 		csa_str, WQ_HIGHPRI | WQ_MEM_RECLAIM | WQ_UNBOUND, 1);
@@ -11817,7 +11817,7 @@ t_void woal_store_firmware_dump(moal_handle *phandle, mlan_event *pmevent)
 					     sizeof(path_name));
 #else
 			memset(path_name, 0, sizeof(path_name));
-			strncpy(path_name, "/data", sizeof(path_name));
+			strscpy(path_name, "/data", sizeof(path_name));
 #endif
 			PRINTM(MMSG, "Firmware Dump directory name is %s\n",
 			       path_name);
@@ -13217,7 +13217,7 @@ mlan_status woal_request_country_power_table(moal_private *priv, char *country,
 	/* file_path should be Null terminated */
 	if (fw_name) {
 		/* file_path[] needs to be reset to 0 before here */
-		strncpy(file_path, fw_name, sizeof(file_path) - 1);
+		strscpy(file_path, fw_name, sizeof(file_path) - 1);
 		last_slash = strrchr(file_path, '/');
 		if (last_slash)
 			memset(last_slash + 1, 0,
@@ -13232,7 +13232,7 @@ mlan_status woal_request_country_power_table(moal_private *priv, char *country,
 
 	if ((strlen(file_path) + strlen(country_name)) <
 	    (sizeof(file_path) - 1))
-		strncpy(file_path + strlen(file_path), country_name,
+		strscpy(file_path + strlen(file_path), country_name,
 			sizeof(file_path) - strlen(file_path) - 1);
 	else {
 		PRINTM(MERROR,
@@ -13275,7 +13275,7 @@ mlan_status woal_request_country_power_table(moal_private *priv, char *country,
 				memset(file_path, 0, sizeof(file_path));
 			if ((strlen(file_path) + strlen(country_name)) <
 			    (sizeof(file_path) - 1))
-				strncpy(file_path + strlen(file_path),
+				strscpy(file_path + strlen(file_path),
 					country_name,
 					sizeof(file_path) - strlen(file_path) -
 						1);
@@ -13332,7 +13332,7 @@ mlan_status woal_dnld_tx_pwr_offset_table(moal_private *priv, char *country,
 		/* Download the 2G mac2 power offset tables */
 		memset(handle->pwr_offset_string, 0,
 		       sizeof(handle->pwr_offset_string));
-		strncpy(handle->pwr_offset_string,
+		strscpy(handle->pwr_offset_string,
 			"region_pwr_offset_cfg_mac2_2G",
 			strlen("region_pwr_offset_cfg_mac2_2G") + 1);
 		if (MLAN_STATUS_SUCCESS !=
@@ -13347,7 +13347,7 @@ mlan_status woal_dnld_tx_pwr_offset_table(moal_private *priv, char *country,
 		/* Download the 2G power offset tables */
 		memset(handle->pwr_offset_string, 0,
 		       sizeof(handle->pwr_offset_string));
-		strncpy(handle->pwr_offset_string, "region_pwr_offset_cfg_2G",
+		strscpy(handle->pwr_offset_string, "region_pwr_offset_cfg_2G",
 			strlen("region_pwr_offset_cfg_2G") + 1);
 		if (MLAN_STATUS_SUCCESS !=
 		    woal_request_country_power_table(priv, country,
@@ -13360,7 +13360,7 @@ mlan_status woal_dnld_tx_pwr_offset_table(moal_private *priv, char *country,
 		/* Download the 5G power offset tables */
 		memset(handle->pwr_offset_string, 0,
 		       sizeof(handle->pwr_offset_string));
-		strncpy(handle->pwr_offset_string, "region_pwr_offset_cfg_5G",
+		strscpy(handle->pwr_offset_string, "region_pwr_offset_cfg_5G",
 			strlen("region_pwr_offset_cfg_5G") + 1);
 		if (MLAN_STATUS_SUCCESS !=
 		    woal_request_country_power_table(priv, country,
@@ -13374,7 +13374,7 @@ mlan_status woal_dnld_tx_pwr_offset_table(moal_private *priv, char *country,
 		/* Download the 6G power offset tables */
 		memset(handle->pwr_offset_string, 0,
 		       sizeof(handle->pwr_offset_string));
-		strncpy(handle->pwr_offset_string, "region_pwr_offset_cfg_6G",
+		strscpy(handle->pwr_offset_string, "region_pwr_offset_cfg_6G",
 			strlen("region_pwr_offset_cfg_6G") + 1);
 		if (MLAN_STATUS_SUCCESS !=
 		    woal_request_country_power_table(priv, country,
@@ -13409,7 +13409,7 @@ mlan_status woal_dnld_ru_power_table(moal_private *priv, char *country,
 		LEAVE();
 		return ret;
 	}
-	strncpy(tmp, priv->phandle->ru_string, sizeof(tmp) - 1);
+	strscpy(tmp, priv->phandle->ru_string, sizeof(tmp) - 1);
 	tmp[sizeof(tmp) - 1] = '\0';
 
 	if (priv->phandle->country_code[0] != 0 &&

--- a/mlinux/moal_proc.c
+++ b/mlinux/moal_proc.c
@@ -1652,7 +1652,7 @@ void woal_proc_init(moal_handle *handle)
 		goto done;
 	}
 
-	strncpy(config_proc_dir, "config", sizeof(config_proc_dir));
+	strscpy(config_proc_dir, "config", sizeof(config_proc_dir));
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)
 	r = proc_create_data(config_proc_dir, 0666, handle->proc_wlan,
 			     &config_proc_fops, handle);
@@ -1667,7 +1667,7 @@ void woal_proc_init(moal_handle *handle)
 		PRINTM(MERROR, "Fail to create proc config\n");
 
 #ifdef DUMP_TO_PROC
-	strncpy(drv_dump_dir, "drv_dump", sizeof(drv_dump_dir));
+	strscpy(drv_dump_dir, "drv_dump", sizeof(drv_dump_dir));
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)
 	r = proc_create_data(drv_dump_dir, 0644, handle->proc_wlan,
 			     &drv_dump_fops, handle);
@@ -1681,7 +1681,7 @@ void woal_proc_init(moal_handle *handle)
 	if (!r)
 		PRINTM(MERROR, "Failed to create proc drv dump\n");
 
-	strncpy(fw_dump_dir, "fw_dump", sizeof(fw_dump_dir));
+	strscpy(fw_dump_dir, "fw_dump", sizeof(fw_dump_dir));
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)
 	r = proc_create_data(fw_dump_dir, 0644, handle->proc_wlan,
 			     &fw_dump_fops, handle);
@@ -1696,7 +1696,7 @@ void woal_proc_init(moal_handle *handle)
 		PRINTM(MERROR, "Failed to create proc fw dump\n");
 
 #if defined(PCIE)
-	strncpy(ssu_dump_dir, "ssu_dump", sizeof(ssu_dump_dir));
+	strscpy(ssu_dump_dir, "ssu_dump", sizeof(ssu_dump_dir));
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)
 	r = proc_create_data(ssu_dump_dir, 0644, handle->proc_wlan,
 			     &ssu_dump_fops, handle);
@@ -1738,15 +1738,15 @@ void woal_proc_exit(moal_handle *handle)
 
 	PRINTM(MINFO, "Remove Proc Interface %s\n", handle->proc_wlan_name);
 	if (handle->proc_wlan) {
-		strncpy(config_proc_dir, "config", sizeof(config_proc_dir));
+		strscpy(config_proc_dir, "config", sizeof(config_proc_dir));
 		remove_proc_entry(config_proc_dir, handle->proc_wlan);
 #ifdef DUMP_TO_PROC
-		strncpy(drv_dump_dir, "drv_dump", sizeof(drv_dump_dir));
+		strscpy(drv_dump_dir, "drv_dump", sizeof(drv_dump_dir));
 		remove_proc_entry(drv_dump_dir, handle->proc_wlan);
-		strncpy(fw_dump_dir, "fw_dump", sizeof(fw_dump_dir));
+		strscpy(fw_dump_dir, "fw_dump", sizeof(fw_dump_dir));
 		remove_proc_entry(fw_dump_dir, handle->proc_wlan);
 #if defined(PCIE)
-		strncpy(ssu_dump_dir, "ssu_dump", sizeof(ssu_dump_dir));
+		strscpy(ssu_dump_dir, "ssu_dump", sizeof(ssu_dump_dir));
 		remove_proc_entry(ssu_dump_dir, handle->proc_wlan);
 #endif
 #endif
@@ -1861,7 +1861,7 @@ void woal_create_proc_entry(moal_private *priv)
 		atomic_inc(&(priv->phandle->proc_wlan->count));
 #endif /* < 3.10.0 */
 #endif /* < 2.6.26 */
-		strncpy(priv->proc_entry_name, dev->name, IFNAMSIZ - 1);
+		strscpy(priv->proc_entry_name, dev->name, IFNAMSIZ - 1);
 		if (priv->proc_entry) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)
 			r = proc_create_data("info", 0, priv->proc_entry,

--- a/mlinux/moal_sdio_mmc.c
+++ b/mlinux/moal_sdio_mmc.c
@@ -1912,21 +1912,21 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 	if (IS_SD8977(handle->card_type)) {
 		switch (revision_id) {
 		case SD8977_V0:
-			strncpy(handle->card_info->fw_name, SD8977_V0_FW_NAME,
+			strscpy(handle->card_info->fw_name, SD8977_V0_FW_NAME,
 				FW_NAMW_MAX_LEN);
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD8977_WLAN_V0_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		case SD8977_V1:
-			strncpy(handle->card_info->fw_name, SD8977_V1_FW_NAME,
+			strscpy(handle->card_info->fw_name, SD8977_V1_FW_NAME,
 				FW_NAMW_MAX_LEN);
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD8977_WLAN_V1_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		case SD8977_V2:
-			strncpy(handle->card_info->fw_name, SD8977_V2_FW_NAME,
+			strscpy(handle->card_info->fw_name, SD8977_V2_FW_NAME,
 				FW_NAMW_MAX_LEN);
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD8977_WLAN_V2_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		default:
@@ -1939,15 +1939,15 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 		/* Check revision ID */
 		switch (revision_id) {
 		case SD8887_A0:
-			strncpy(handle->card_info->fw_name, SD8887_A0_FW_NAME,
+			strscpy(handle->card_info->fw_name, SD8887_A0_FW_NAME,
 				FW_NAMW_MAX_LEN);
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD8887_WLAN_A0_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		case SD8887_A2:
-			strncpy(handle->card_info->fw_name, SD8887_A2_FW_NAME,
+			strscpy(handle->card_info->fw_name, SD8887_A2_FW_NAME,
 				FW_NAMW_MAX_LEN);
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD8887_WLAN_A2_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		default:
@@ -1960,11 +1960,11 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 	if (IS_SD8987(handle->card_type)) {
 		if (magic == CHIP_MAGIC_VALUE) {
 			if (strap == CARD_TYPE_SD_UART)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUART8987_DEFAULT_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDSD8987_DEFAULT_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 		}
@@ -1975,11 +1975,11 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 	if (IS_SD8978(handle->card_type)) {
 		if (magic == CHIP_MAGIC_VALUE) {
 			if (strap == CARD_TYPE_SD_UART)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUART8978_DEFAULT_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDSD8978_DEFAULT_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 		}
@@ -1993,15 +1993,15 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 		case SD9098_Z1Z2:
 			if (magic == CHIP_MAGIC_VALUE) {
 				if (strap == CARD_TYPE_SD_UART)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDUART9098_DEFAULT_COMBO_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDSD9098_DEFAULT_COMBO_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			}
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD9098_DEFAULT_WLAN_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		case SD9098_A0:
@@ -2009,19 +2009,19 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 		case SD9098_A2:
 			if (magic == CHIP_MAGIC_VALUE) {
 				if (strap == CARD_TYPE_SD_UART)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDUART9098_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDSD9098_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			} else {
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUART9098_COMBO_V1_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			}
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD9098_WLAN_V1_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		default:
@@ -2036,15 +2036,15 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 		case SD9097_B1:
 			if (magic == CHIP_MAGIC_VALUE) {
 				if (strap == CARD_TYPE_SD_UART)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDUART9097_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDSD9097_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			}
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD9097_WLAN_V1_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		default:
@@ -2061,26 +2061,26 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 		switch (revision_id) {
 		case SDAW693_A0:
 			if (strap == CARD_TYPE_SDAW693_UART)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTIW693_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDSDIW693_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SDIW693_DEFAULT_WLAN_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		case SDAW693_A1:
 			if (strap == CARD_TYPE_SDAW693_UART)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTIW693_COMBO_V1_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDSDIW693_COMBO_V1_FW_NAME,
 					FW_NAMW_MAX_LEN);
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SDIW693_WLAN_V1_FW_NAME, FW_NAMW_MAX_LEN);
 			if (magic != 0x03) {
 				/* remove extension .se */
@@ -2108,24 +2108,24 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 			PRINTM(MMSG, "wlan: SDIW624 in secure-boot mode\n");
 		if (strap == CARD_TYPE_SDIW624_UARTSPI) {
 			if (handle->params.dual_nb)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTSPIIW624_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTIW624_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 		} else if (strap == CARD_TYPE_SDIW624_UARTUART) {
 			if (handle->params.dual_nb)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTUARTIW624_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTIW624_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 		} else {
-			strncpy(handle->card_info->fw_name,
+			strscpy(handle->card_info->fw_name,
 				SDSDIW624_COMBO_FW_NAME, FW_NAMW_MAX_LEN);
 		}
 	}
@@ -2137,58 +2137,58 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 		case SD9177_A0:
 			if (magic == CHIP_MAGIC_VALUE) {
 				if (strap == CARD_TYPE_SD9177_UART)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDUART9177_DEFAULT_COMBO_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDSD9177_DEFAULT_COMBO_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			}
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				SD9177_DEFAULT_WLAN_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		case SD9177_A1:
 			if (magic == CHIP_MAGIC_VALUE) {
 				if (strap == CARD_TYPE_SD9177_UART) {
 					if (handle->params.rf_test_mode)
-						strncpy(handle->card_info
+						strscpy(handle->card_info
 								->fw_name,
 							SDUART9177_DEFAULT_RFTM_COMBO_V1_FW_NAME,
 							FW_NAMW_MAX_LEN);
 					else
-						strncpy(handle->card_info
+						strscpy(handle->card_info
 								->fw_name,
 							SDUART9177_DEFAULT_COMBO_V1_FW_NAME,
 							FW_NAMW_MAX_LEN);
 				} else {
 					if (handle->params.rf_test_mode)
-						strncpy(handle->card_info
+						strscpy(handle->card_info
 								->fw_name,
 							SDSD9177_DEFAULT_RFTM_COMBO_V1_FW_NAME,
 							FW_NAMW_MAX_LEN);
 					else
-						strncpy(handle->card_info
+						strscpy(handle->card_info
 								->fw_name,
 							SDSD9177_DEFAULT_COMBO_V1_FW_NAME,
 							FW_NAMW_MAX_LEN);
 				}
 			} else {
 				if (handle->params.rf_test_mode)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SDUART9177_DEFAULT_RFTM_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						SD9177_DEFAULT_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			}
 			if (handle->params.rf_test_mode)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SD9177_DEFAULT_RFTM_WLAN_V1_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name_wlan,
+				strscpy(handle->card_info->fw_name_wlan,
 					SD9177_DEFAULT_WLAN_V1_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			break;
@@ -2205,15 +2205,15 @@ static mlan_status woal_sdiommc_get_fw_name(moal_handle *handle)
 			PRINTM(MMSG, "wlan: SDIW610 in secure-boot mode\n");
 		if (strap == CARD_TYPE_SDIW610_UART) {
 			if (handle->params.dual_nb)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTSPIIW610_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					SDUARTIW610_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 		}
-		strncpy(handle->card_info->fw_name_wlan,
+		strscpy(handle->card_info->fw_name_wlan,
 			SDIW610_DEFAULT_WLAN_FW_NAME, FW_NAMW_MAX_LEN);
 		if (magic != 0x03) {
 			/* remove extension .se */
@@ -2425,7 +2425,7 @@ void woal_dump_firmware_info_v2(moal_handle *phandle)
 	woal_create_dump_dir(phandle, path_name, sizeof(path_name));
 #else
 	memset(path_name, 0, sizeof(path_name));
-	strncpy(path_name, "/data", sizeof(path_name));
+	strscpy(path_name, "/data", sizeof(path_name));
 #endif
 	PRINTM(MMSG, "Directory name is %s\n", path_name);
 
@@ -2659,7 +2659,7 @@ void woal_dump_firmware_info_v3(moal_handle *phandle)
 	woal_create_dump_dir(phandle, path_name, sizeof(path_name));
 #else
 	memset(path_name, 0, sizeof(path_name));
-	strncpy(path_name, "/data", sizeof(path_name));
+	strscpy(path_name, "/data", sizeof(path_name));
 #endif
 	PRINTM(MMSG, "Directory name is %s\n", path_name);
 	ref_handle = (moal_handle *)phandle->pref_mac;

--- a/mlinux/moal_sta_cfg80211.c
+++ b/mlinux/moal_sta_cfg80211.c
@@ -269,7 +269,11 @@ woal_cfg80211_remain_on_channel(struct wiphy *wiphy,
 #if CFG80211_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
 				enum nl80211_channel_type channel_type,
 #endif
-				unsigned int duration, u64 *cookie);
+				unsigned int duration, u64 *cookie
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				, const u8 *rx_addr
+#endif
+);
 
 static int woal_cfg80211_cancel_remain_on_channel(struct wiphy *wiphy,
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
@@ -7794,7 +7798,11 @@ woal_cfg80211_remain_on_channel(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if CFG80211_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
 				enum nl80211_channel_type channel_type,
 #endif
-				unsigned int duration, u64 *cookie)
+				unsigned int duration, u64 *cookie
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				, const u8 *rx_addr
+#endif
+)
 #else
 /**
  * @brief Make chip remain on channel

--- a/mlinux/moal_sta_cfg80211.c
+++ b/mlinux/moal_sta_cfg80211.c
@@ -5410,7 +5410,7 @@ woal_cfg80211_reg_notifier(struct wiphy *wiphy,
 			if (handle->second_mac &&
 			    IS_CARDAW693(priv->phandle->card_type) &&
 			    wiphy->bands[IEEE80211_BAND_2GHZ]) {
-				strncpy(handle->ru_string,
+				strscpy(handle->ru_string,
 					"subband_ru_power_cfg_mac2_2G",
 					strlen("subband_ru_power_cfg_mac2_2G") +
 						1);
@@ -5426,7 +5426,7 @@ woal_cfg80211_reg_notifier(struct wiphy *wiphy,
 				 * tables */
 				memset(handle->ru_string, 0,
 				       sizeof(handle->ru_string));
-				strncpy(handle->ru_string,
+				strscpy(handle->ru_string,
 					"subband_ru_power_cfg_2G_5G",
 					strlen("subband_ru_power_cfg_2G_5G") +
 						1);
@@ -5442,7 +5442,7 @@ woal_cfg80211_reg_notifier(struct wiphy *wiphy,
 				/* Download the 6G RU power table */
 				memset(handle->ru_string, 0,
 				       sizeof(handle->ru_string));
-				strncpy(handle->ru_string,
+				strscpy(handle->ru_string,
 					"subband_ru_power_cfg_6G",
 					strlen("subband_ru_power_cfg_6G") + 1);
 				if (MLAN_STATUS_SUCCESS !=
@@ -8062,7 +8062,7 @@ int woal_cfg80211_sched_scan_start(struct wiphy *wiphy, struct net_device *dev,
 		priv->scan_cfg.start_later = MTRUE;
 	for (i = 0; i < request->n_ssids; i++) {
 		ssid = &request->ssids[i];
-		strncpy(priv->scan_cfg.ssid_list[index].ssid, ssid->ssid,
+		strscpy(priv->scan_cfg.ssid_list[index].ssid, ssid->ssid,
 			ssid->ssid_len);
 		if (ssid->ssid_len) {
 			priv->scan_cfg.ssid_list[index].max_len = 0;
@@ -8081,7 +8081,7 @@ int woal_cfg80211_sched_scan_start(struct wiphy *wiphy, struct net_device *dev,
 				break;
 		}
 		if (j == request->n_ssids) {
-			strncpy(priv->scan_cfg.ssid_list[index].ssid,
+			strscpy(priv->scan_cfg.ssid_list[index].ssid,
 				match_ssid->ssid, match_ssid->ssid_len);
 			priv->scan_cfg.ssid_list[index].max_len =
 				match_ssid->ssid_len;
@@ -12687,13 +12687,13 @@ void woal_dnld_sta_6e_psd_table(moal_private *priv, t_u8 *resp_buf,
 	/* Indoor Mode */
 	case AP_MODE_IND: {
 		/* Copy the initial Reg power string */
-		strncpy(priv->phandle->mode_psd_string,
+		strscpy(priv->phandle->mode_psd_string,
 			"region_pwr_cfg_6G_PSD_",
 			strlen("region_pwr_cfg_6G_PSD_") + 1);
-		strncpy(priv->phandle->pwr_offset_string,
+		strscpy(priv->phandle->pwr_offset_string,
 			"region_pwr_offset_cfg_6G_PSD_",
 			strlen("region_pwr_offset_cfg_6G_PSD_") + 1);
-		strncpy(tmp, "subband_ru_power_cfg_6G_PSD_",
+		strscpy(tmp, "subband_ru_power_cfg_6G_PSD_",
 			strlen("subband_ru_power_cfg_6G_PSD_") + 1);
 		/* Prepare the 6E operation mode/psd based string */
 		switch (priv->phandle->dfs_region) {
@@ -12738,13 +12738,13 @@ void woal_dnld_sta_6e_psd_table(moal_private *priv, t_u8 *resp_buf,
 	/* Standard Power Mode */
 	case AP_MODE_SP: {
 		/* Copy the initial Reg power string */
-		strncpy(priv->phandle->mode_psd_string,
+		strscpy(priv->phandle->mode_psd_string,
 			"region_pwr_cfg_6G_PSD_",
 			strlen("region_pwr_cfg_6G_PSD_") + 1);
-		strncpy(priv->phandle->pwr_offset_string,
+		strscpy(priv->phandle->pwr_offset_string,
 			"region_pwr_offset_cfg_6G_PSD_",
 			strlen("region_pwr_offset_cfg_6G_PSD_") + 1);
-		strncpy(tmp, "subband_ru_power_cfg_6G_PSD_",
+		strscpy(tmp, "subband_ru_power_cfg_6G_PSD_",
 			strlen("subband_ru_power_cfg_6G_PSD_") + 1);
 		/* Prepare the 6E operation mode/psd based string */
 		switch (priv->phandle->dfs_region) {
@@ -12789,13 +12789,13 @@ void woal_dnld_sta_6e_psd_table(moal_private *priv, t_u8 *resp_buf,
 	/* Very Low Power Mode */
 	case AP_MODE_VLP: {
 		/* Copy the initial Reg power string */
-		strncpy(priv->phandle->mode_psd_string,
+		strscpy(priv->phandle->mode_psd_string,
 			"region_pwr_cfg_6G_PSD_",
 			strlen("region_pwr_cfg_6G_PSD_") + 1);
-		strncpy(priv->phandle->pwr_offset_string,
+		strscpy(priv->phandle->pwr_offset_string,
 			"region_pwr_offset_cfg_6G_PSD_",
 			strlen("region_pwr_offset_cfg_6G_PSD_") + 1);
-		strncpy(tmp, "subband_ru_power_cfg_6G_PSD_",
+		strscpy(tmp, "subband_ru_power_cfg_6G_PSD_",
 			strlen("subband_ru_power_cfg_6G_PSD_") + 1);
 		/* Prepare the 6E operation mode/psd based string */
 		switch (priv->phandle->dfs_region) {
@@ -12864,7 +12864,7 @@ void woal_dnld_sta_6e_psd_table(moal_private *priv, t_u8 *resp_buf,
 	       sizeof(priv->phandle->pwr_offset_string));
 
 	/* Download the ex-AP mode specific PSD RU table */
-	strncpy(priv->phandle->ru_string, tmp,
+	strscpy(priv->phandle->ru_string, tmp,
 		sizeof(priv->phandle->ru_string) - 1);
 	if (MLAN_STATUS_SUCCESS !=
 	    woal_dnld_ru_power_table(priv, country_code, MOAL_NO_WAIT)) {
@@ -12901,9 +12901,9 @@ mlan_status woal_dnld_default_6e_psd_table(moal_private *priv)
 	       sizeof(priv->phandle->pwr_offset_string));
 	memset(priv->phandle->ru_string, 0, sizeof(priv->phandle->ru_string));
 	/* Copy the initial Reg power string */
-	strncpy(priv->phandle->mode_psd_string, "region_pwr_cfg_6G",
+	strscpy(priv->phandle->mode_psd_string, "region_pwr_cfg_6G",
 		strlen("region_pwr_cfg_6G") + 1);
-	strncpy(priv->phandle->pwr_offset_string, "region_pwr_offset_cfg_6G",
+	strscpy(priv->phandle->pwr_offset_string, "region_pwr_offset_cfg_6G",
 		strlen("region_pwr_offset_cfg_6G") + 1);
 
 	PRINTM(MMSG, "Opmode string = %s\n", priv->phandle->mode_psd_string);
@@ -12926,7 +12926,7 @@ mlan_status woal_dnld_default_6e_psd_table(moal_private *priv)
 	}
 	memset(priv->phandle->pwr_offset_string, 0,
 	       sizeof(priv->phandle->pwr_offset_string));
-	strncpy(priv->phandle->ru_string, "subband_ru_power_cfg_6G",
+	strscpy(priv->phandle->ru_string, "subband_ru_power_cfg_6G",
 		strlen("subband_ru_power_cfg_6G") + 1);
 
 	if (MLAN_STATUS_SUCCESS !=

--- a/mlinux/moal_uap.c
+++ b/mlinux/moal_uap.c
@@ -4084,7 +4084,7 @@ static int woal_uap_ap_cfg_parse_data(moal_private *priv,
 					goto done;
 				}
 				ap_cfg->ssid.ssid_len = strlen(value);
-				strncpy((char *)ap_cfg->ssid.ssid, value,
+				strscpy((char *)ap_cfg->ssid.ssid, value,
 					MLAN_MAX_SSID_LENGTH - 1);
 				ap_cfg->ssid.ssid[MLAN_MAX_SSID_LENGTH - 1] =
 					'\0';

--- a/mlinux/moal_uap_cfg80211.c
+++ b/mlinux/moal_uap_cfg80211.c
@@ -1418,13 +1418,13 @@ void woal_dnld_uap_6e_psd_table(moal_private *priv, const t_u8 *beacon_buf,
 		/* Indoor Mode */
 		case UAP_MODE_IND: {
 			/* Copy the initial Reg power string */
-			strncpy(priv->phandle->mode_psd_string,
+			strscpy(priv->phandle->mode_psd_string,
 				"region_pwr_cfg_6G_PSD_",
 				strlen("region_pwr_cfg_6G_PSD_") + 1);
-			strncpy(priv->phandle->pwr_offset_string,
+			strscpy(priv->phandle->pwr_offset_string,
 				"region_pwr_offset_cfg_6G_PSD_",
 				strlen("region_pwr_offset_cfg_6G_PSD_") + 1);
-			strncpy(tmp, "subband_ru_power_cfg_6G_PSD_",
+			strscpy(tmp, "subband_ru_power_cfg_6G_PSD_",
 				strlen("subband_ru_power_cfg_6G_PSD_") + 1);
 			/* Prepare the 6E operation mode/psd based string */
 			switch (priv->phandle->dfs_region) {
@@ -1476,13 +1476,13 @@ void woal_dnld_uap_6e_psd_table(moal_private *priv, const t_u8 *beacon_buf,
 		/* Standard Power Mode */
 		case UAP_MODE_SP: {
 			/* Copy the initial Reg power string */
-			strncpy(priv->phandle->mode_psd_string,
+			strscpy(priv->phandle->mode_psd_string,
 				"region_pwr_cfg_6G_PSD_",
 				strlen("region_pwr_cfg_6G_PSD_") + 1);
-			strncpy(priv->phandle->pwr_offset_string,
+			strscpy(priv->phandle->pwr_offset_string,
 				"region_pwr_offset_cfg_6G_PSD_",
 				strlen("region_pwr_offset_cfg_6G_PSD_") + 1);
-			strncpy(tmp, "subband_ru_power_cfg_6G_PSD_",
+			strscpy(tmp, "subband_ru_power_cfg_6G_PSD_",
 				strlen("subband_ru_power_cfg_6G_PSD_") + 1);
 
 			/* Prepare the 6E operation mode/psd based string */
@@ -1535,13 +1535,13 @@ void woal_dnld_uap_6e_psd_table(moal_private *priv, const t_u8 *beacon_buf,
 		/* Very Low Power Mode */
 		case UAP_MODE_VLP: {
 			/* Copy the initial Reg power string */
-			strncpy(priv->phandle->mode_psd_string,
+			strscpy(priv->phandle->mode_psd_string,
 				"region_pwr_cfg_6G_PSD_",
 				strlen("region_pwr_cfg_6G_PSD_") + 1);
-			strncpy(priv->phandle->pwr_offset_string,
+			strscpy(priv->phandle->pwr_offset_string,
 				"region_pwr_offset_cfg_6G_PSD_",
 				strlen("region_pwr_offset_cfg_6G_PSD_") + 1);
-			strncpy(tmp, "subband_ru_power_cfg_6G_PSD_",
+			strscpy(tmp, "subband_ru_power_cfg_6G_PSD_",
 				strlen("subband_ru_power_cfg_6G_PSD_") + 1);
 			/* Prepare the 6E operation mode/psd based string */
 			switch (priv->phandle->dfs_region) {
@@ -1623,7 +1623,7 @@ void woal_dnld_uap_6e_psd_table(moal_private *priv, const t_u8 *beacon_buf,
 		       sizeof(priv->phandle->pwr_offset_string));
 
 		/* Download the uAP mode specific PSD RU table */
-		strncpy(priv->phandle->ru_string, tmp,
+		strscpy(priv->phandle->ru_string, tmp,
 			sizeof(priv->phandle->ru_string) - 1);
 		if (MLAN_STATUS_SUCCESS !=
 		    woal_dnld_ru_power_table(priv, country_code,

--- a/mlinux/moal_uap_wext.c
+++ b/mlinux/moal_uap_wext.c
@@ -221,7 +221,7 @@ static int woal_get_name(struct net_device *dev, struct iw_request_info *info,
 	char *cwrq = wrqu->name;
 
 	ENTER();
-	strncpy(cwrq, "IEEE 802.11-DS", IFNAMSIZ);
+	strscpy(cwrq, "IEEE 802.11-DS", IFNAMSIZ);
 	LEAVE();
 	return 0;
 }

--- a/mlinux/moal_usb.c
+++ b/mlinux/moal_usb.c
@@ -2154,11 +2154,11 @@ static mlan_status woal_usb_get_fw_name(moal_handle *handle)
 #ifdef USB8978
 	if (IS_USB8978(handle->card_type)) {
 		if (strap == CARD_TYPE_USB_UART)
-			strncpy(handle->card_info->fw_name,
+			strscpy(handle->card_info->fw_name,
 				USBUART8978_DEFAULT_COMBO_FW_NAME,
 				FW_NAMW_MAX_LEN);
 		else if (strap != 0)
-			strncpy(handle->card_info->fw_name,
+			strscpy(handle->card_info->fw_name,
 				USBUSB8978_DEFAULT_COMBO_FW_NAME,
 				FW_NAMW_MAX_LEN);
 	}
@@ -2169,10 +2169,10 @@ static mlan_status woal_usb_get_fw_name(moal_handle *handle)
 		if (cardp->second_mac) {
 			ref_handle = (moal_handle *)handle->pref_mac;
 			if (ref_handle) {
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					ref_handle->card_info->fw_name,
 					FW_NAMW_MAX_LEN);
-				strncpy(handle->card_info->fw_name_wlan,
+				strscpy(handle->card_info->fw_name_wlan,
 					ref_handle->card_info->fw_name_wlan,
 					FW_NAMW_MAX_LEN);
 			}
@@ -2182,15 +2182,15 @@ static mlan_status woal_usb_get_fw_name(moal_handle *handle)
 		case USB9098_Z1Z2:
 			if (strap != 0) {
 				if (strap == CARD_TYPE_USB_UART)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						USBUART9098_DEFAULT_COMBO_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						USBUSB9098_DEFAULT_COMBO_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			}
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				USB9098_DEFAULT_WLAN_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		case USB9098_A0:
@@ -2198,15 +2198,15 @@ static mlan_status woal_usb_get_fw_name(moal_handle *handle)
 		case USB9098_A2:
 			if (strap != 0) {
 				if (strap == CARD_TYPE_USB_UART)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						USBUART9098_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						USBUSB9098_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			}
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				USB9098_WLAN_V1_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		}
@@ -2219,15 +2219,15 @@ static mlan_status woal_usb_get_fw_name(moal_handle *handle)
 		case USB9097_B1:
 			if (strap != 0) {
 				if (strap == CARD_TYPE_USB_UART)
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						USBUART9097_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 				else
-					strncpy(handle->card_info->fw_name,
+					strscpy(handle->card_info->fw_name,
 						USBUSB9097_COMBO_V1_FW_NAME,
 						FW_NAMW_MAX_LEN);
 			}
-			strncpy(handle->card_info->fw_name_wlan,
+			strscpy(handle->card_info->fw_name_wlan,
 				USB9097_WLAN_V1_FW_NAME, FW_NAMW_MAX_LEN);
 			break;
 		}
@@ -2238,10 +2238,10 @@ static mlan_status woal_usb_get_fw_name(moal_handle *handle)
 		if (boot_mode == 0x03)
 			PRINTM(MMSG, "wlan: USB-IW624 in secure-boot mode\n");
 		if (strap == CARD_TYPE_USB_UART)
-			strncpy(handle->card_info->fw_name,
+			strscpy(handle->card_info->fw_name,
 				USBUARTIW624_COMBO_FW_NAME, FW_NAMW_MAX_LEN);
 		else
-			strncpy(handle->card_info->fw_name,
+			strscpy(handle->card_info->fw_name,
 				USBUSBIW624_COMBO_FW_NAME, FW_NAMW_MAX_LEN);
 	}
 #endif
@@ -2251,24 +2251,24 @@ static mlan_status woal_usb_get_fw_name(moal_handle *handle)
 			PRINTM(MMSG, "wlan: USB-IW610 in secure-boot mode\n");
 		if (strap == CARD_TYPE_USBIW610_UART) {
 			if (handle->params.dual_nb)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					USBUARTSPIIW610_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					USBUARTIW610_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 		} else if (strap == CARD_TYPE_USBIW610_USB) {
 			if (handle->params.dual_nb)
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					USBUSBSPIIW610_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 			else
-				strncpy(handle->card_info->fw_name,
+				strscpy(handle->card_info->fw_name,
 					USBUSBIW610_COMBO_FW_NAME,
 					FW_NAMW_MAX_LEN);
 		}
-		strncpy(handle->card_info->fw_name_wlan,
+		strscpy(handle->card_info->fw_name_wlan,
 			USBIW610_DEFAULT_WLAN_FW_NAME, FW_NAMW_MAX_LEN);
 		if (boot_mode != 0x03) {
 			/* remove extension .se */
@@ -2321,7 +2321,7 @@ static int parse_config_line(char *line, usb_config_entry_t *entry,
 			}
 
 			current_entry = &entry[*current_entry_idx];
-			strncpy(current_entry->device_name, strim(token),
+			strscpy(current_entry->device_name, strim(token),
 				MAX_DEVICE_NAME - 1);
 			current_entry->device_name[MAX_DEVICE_NAME - 1] = '\0';
 

--- a/mlinux/moal_wext.c
+++ b/mlinux/moal_wext.c
@@ -353,7 +353,7 @@ static int woal_get_nick(struct net_device *dev, struct iw_request_info *info,
 	/*
 	 * Get the Nick Name saved
 	 */
-	strncpy(extra, (char *)priv->nick_name, 16);
+	strscpy(extra, (char *)priv->nick_name, 16);
 	extra[16] = '\0';
 	/*
 	 * If none, we may want to get the one that was set
@@ -403,7 +403,7 @@ static int woal_get_name(struct net_device *dev, struct iw_request_info *info,
 	char *cwrq = wrqu->name;
 
 	ENTER();
-	strncpy(cwrq, "IEEE 802.11-DS", IFNAMSIZ);
+	strscpy(cwrq, "IEEE 802.11-DS", IFNAMSIZ);
 	LEAVE();
 	return 0;
 }


### PR DESCRIPTION
- Replaced all instances of `strncpy` with `strscpy`
- Added `const u8 *rx_addr` to `woal_cfg80211_remain_on_channel`

This were the bare minimum changes to get it compile on a 7.2 kernel but I am not a position where I can test this.